### PR TITLE
added a test for member functions' reference qualifiers

### DIFF
--- a/src/reference-qualifiers.cpp
+++ b/src/reference-qualifiers.cpp
@@ -1,0 +1,7 @@
+// check if reference qualifiers for member functions are supported
+// http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2439.htm
+struct X
+{
+   void f() &;
+   void f() &&;
+};


### PR DESCRIPTION
I couldn't find a test for ref-qualifiers on member functions, so I thought it's worth adding one.
