### PR TITLE
perl equivalent of python scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Installation & Requirements
 
 The following software packages are needed to run cxx11tests:
 
-*   Python 3 (>= 3.3)
+*   Python 3 (>= 3.3) or Perl > 5.0
 *   GNU Make
 *   any C++ compiler
 
@@ -83,8 +83,8 @@ Usage
 -----
 
 After downloading (and unpacking, if necessary), enter the cxx11tests directory.
-To prepare the tests, you need to run the `configure.py` script once to generate
-the Makefile that will run the tests. The configure script respects three
+To prepare the tests, you need to run either the `configure.py` script or the `configure.pl`script
+once to generate the Makefile that will run the tests. The configure script respects three
 environment variables that you may use to set the compiler command and any
 necessary flags:
 
@@ -96,14 +96,18 @@ If you want to check e.g. the currently installed GNU compiler, you could run
 configure as
 
     CXX=g++ CXXFLAGS=-std=c++11 ./configure.py
+or
+    CXX=g++ CXXFLAGS=-std=c++11 ./configure.pl
 
 You may also run the configure script from another directory (out-of-source
 tests).
 
 After running the configure script, you can run the tests using `make`. By
-default, all tests are run. To start them, just execute
+default, all tests are run. Makefile is using gmake syntax. To start them, just execute
 
-    make
+    make 
+or
+    gmake
 
 and and wait for the tests to finish. Make will not stop after failed tests, but
 continue until all tests have been run. On subsequent calls to `make`, only
@@ -111,6 +115,8 @@ tests that previously failed will be run again. To override this behavior and
 run all tests regardless of their previous status, run the 'force' target, i.e.
 
     make force
+or
+    gmake force
 
 If you want to clean out all previously run tests, call `make clean`. `make
 distclean` will also delete the Makefile, so you will have to run the configure
@@ -124,6 +130,8 @@ tests. You can switch of colors by setting the environment variable `COLORIZED`
 to '0' (zero), or my calling make with
 
     make COLORIZED=0
+or
+    gmake COLORIZED=0
 
 
 Contributions

--- a/configure.pl
+++ b/configure.pl
@@ -1,0 +1,172 @@
+#!/usr/bin/env perl
+
+package main;
+
+my $root_dir = `pwd | tr -d "\n"`; 
+my $src_dir = $root_dir.'/src';
+my $m = new MakefileGen($root_dir, $src_dir, 'build', 'cpp', 'g++');
+$m->generate();
+exit 0;
+
+
+package MakefileGen;
+
+sub new()
+{
+  my $super = shift;
+  my $root_dir = shift || '.';
+  my $src_dir = shift || '.';
+  my $build_dir = shift || 'build';
+  my $ext = shift || 'cpp';
+  my $compiler = shift || 'g++';
+  
+  my $this = {
+    root_dir => $root_dir,
+    build_dir => $build_dir,
+    source_dir => $src_dir,
+    extension => $ext,
+    compiler => $compiler,
+    files => [],
+    tests => [],
+    makefile_header => [],
+    makefile_targets => [],
+    makefile_footer => [],
+  };
+  bless($this, $super);
+  return $this;
+}
+
+sub generate()
+{
+  my $self = shift;
+  $self->clean_build_directory();
+  $self->scan_source_directory();
+  $self->create_makefile_header();
+  $self->create_makefile_targets();
+  $self->create_makefile_footer();
+  $self->write_makefile();
+  print("Done.\n");
+}
+
+sub clean_build_directory()
+{
+  my $self = shift;
+  if (-d $self->{build_dir})
+  {
+    my $cmd = 'rm -Rf '.$self->{build_dir};
+    system($cmd);
+    print("Existing build directory removed.\n");
+  }
+}
+
+sub scan_source_directory()
+{
+  my $self = shift;
+  my @f = glob($self->{source_dir}.'/*.'.$self->{extension});
+  my $ext = $self->{extension};
+  my @t = map { `basename $_ .$ext | tr -d '\n'` } @f;
+  $self->{files} = \@f;
+  $self->{tests} = \@t;
+  print("Source directory scanned for test files.\n");
+}
+
+sub create_makefile_header()
+{
+  my $self = shift;
+  $self->{makefile_header} = [];
+  my $CXX = $ENV{CXX} || $self->{compiler};
+  my $CPPFLAGS = $ENV{CPPFLAGS} || '';
+  my $CXXFLAGS = $ENV{CXXFLAGS} || '';
+
+  push @{$self->{makefile_header}}, "# Command to regenerate this Makefile:";
+  push @{$self->{makefile_header}}, "# CXX=$CXX CPPFLAGS=$CPPFLAGS CXXFLAGS=$CXXFLAGS";
+  push @{$self->{makefile_header}}, "";
+  push @{$self->{makefile_header}}, "ROOT := ".$self->{root_dir};
+  push @{$self->{makefile_header}}, "SRC := ".$self->{source_dir};
+  push @{$self->{makefile_header}}, "BLD := ".$self->{build_dir};
+  push @{$self->{makefile_header}}, "RT := \$(ROOT)/runtest.pl";
+  push @{$self->{makefile_header}}, "CXX := $CXX";
+  push @{$self->{makefile_header}}, "CPPFLAGS := $CPPFLAGS";
+  push @{$self->{makefile_header}}, "CXXFLAGS := $CXXFLAGS";
+  print("Makefile header generated.\n");
+}
+
+sub create_makefile_targets()
+{
+  my $self = shift;
+
+  push @{$self->{makefile_targets}}, "";
+  push @{$self->{makefile_targets}}, "# Default target";
+  push @{$self->{makefile_targets}}, "all: tests";
+  push @{$self->{makefile_targets}}, "";
+  push @{$self->{makefile_targets}}, "# Create build directory";
+  push @{$self->{makefile_targets}}, "\$(BLD):";
+  push @{$self->{makefile_targets}}, "\t\@mkdir -p \$(BLD)";
+  push @{$self->{makefile_targets}}, "";
+  push @{$self->{makefile_targets}}, "# Run all tests";
+  push @{$self->{makefile_targets}}, "tests: ".join(' ', @{$self->{tests}});
+  push @{$self->{makefile_targets}}, "";
+  push @{$self->{makefile_targets}}, "# Force rebuilding all tests";
+  push @{$self->{makefile_targets}}, "force: clean all";
+
+  for (my $i = 0; $i < scalar @{$self->{tests}}; $i++)
+  {
+    my $test = $self->{tests}->[$i];
+    my $filename = $self->{files}->[$i];
+    push @{$self->{makefile_targets}}, "";
+    push @{$self->{makefile_targets}}, "# Build rules for $test";
+    push @{$self->{makefile_targets}}, "\$(BLD)/$test.o: \$(SRC)/$test.cpp | \$(BLD)";
+    push @{$self->{makefile_targets}}, "\t\@\$(RT) $test \$(BLD)/$test.log \\";
+    push @{$self->{makefile_targets}}, "\t\t\$(CXX) -c \$(CPPFLAGS) \$(CXXFLAGS) -o \\";
+    push @{$self->{makefile_targets}}, "\t\t\$(BLD)/$test.o \$(SRC)/$test.cpp";
+    push @{$self->{makefile_targets}}, "";
+    push @{$self->{makefile_targets}}, "$test: \$(BLD)/$test.o";
+  }
+
+  push @{$self->{makefile_targets}}, "";
+  push @{$self->{makefile_targets}}, "# Phony targets";
+  push @{$self->{makefile_targets}}, ".PHONY: all clean distclean help";
+  push @{$self->{makefile_targets}}, "";
+  push @{$self->{makefile_targets}}, "# Clean up test files";
+  push @{$self->{makefile_targets}}, "clean:";
+  push @{$self->{makefile_targets}}, "\t\@rm -f \$(BLD)/*.o \$(BLD)/*.log";
+  push @{$self->{makefile_targets}}, "";
+  push @{$self->{makefile_targets}}, "# Clean up everything";
+  push @{$self->{makefile_targets}}, "distclean: clean";
+  push @{$self->{makefile_targets}}, "\t\@rm -f Makefile";
+  push @{$self->{makefile_targets}}, "";
+  push @{$self->{makefile_targets}}, "# Show targets that can be built";
+  push @{$self->{makefile_targets}}, "help:";
+  push @{$self->{makefile_targets}}, "\t\@echo 'The following targets can be built:'";
+  push @{$self->{makefile_targets}}, "\t\@echo '  all (subault)'";
+  push @{$self->{makefile_targets}}, "\t\@echo '  tests'";
+  push @{$self->{makefile_targets}}, "\t\@echo '  force'";
+  push @{$self->{makefile_targets}}, "\t\@echo '  clean'";
+  push @{$self->{makefile_targets}}, "\t\@echo '  distclean'";
+  push @{$self->{makefile_targets}}, "\t\@echo '  help'";
+
+  foreach my $test (@{$self->{tests}})
+  {
+    push @{$self->{makefile_targets}}, "\t\@echo '  $test'";
+  }
+  print("Makefile targets generated.\n");
+}
+
+sub create_makefile_footer()
+{
+  print("Makefile footer generated.\n")
+}
+
+sub write_makefile()
+{
+  my $self = shift;
+  
+  open F, "> Makefile" or die "open Makefile: $!";
+  print F join("\n", @{$self->{makefile_header}});
+  print F "\n";
+  print F join("\n", @{$self->{makefile_targets}});
+  print F "\n";
+  print F join("\n", @{$self->{makefile_footer}});
+  close F;
+  print("Makefile written to disk.\n")
+}  

--- a/configure.pl
+++ b/configure.pl
@@ -20,6 +20,7 @@ sub new()
   my $ext = shift || 'cpp';
   my $compiler = shift || 'g++';
   
+  # Save arguments and init member variables
   my $this = {
     root_dir => $root_dir,
     build_dir => $build_dir,
@@ -74,20 +75,34 @@ sub create_makefile_header()
 {
   my $self = shift;
   $self->{makefile_header} = [];
+  # Get configuration options
   my $CXX = $ENV{CXX} || $self->{compiler};
   my $CPPFLAGS = $ENV{CPPFLAGS} || '';
   my $CXXFLAGS = $ENV{CXXFLAGS} || '';
 
+  # Add command that can be used to recreate the same Makefile
   push @{$self->{makefile_header}}, "# Command to regenerate this Makefile:";
   push @{$self->{makefile_header}}, "# CXX=$CXX CPPFLAGS=$CPPFLAGS CXXFLAGS=$CXXFLAGS";
   push @{$self->{makefile_header}}, "";
+
+  # Add directories and executables
   push @{$self->{makefile_header}}, "ROOT := ".$self->{root_dir};
   push @{$self->{makefile_header}}, "SRC := ".$self->{source_dir};
   push @{$self->{makefile_header}}, "BLD := ".$self->{build_dir};
   push @{$self->{makefile_header}}, "RT := \$(ROOT)/runtest.pl";
+
+  # Add compiler executable if specified
   push @{$self->{makefile_header}}, "CXX := $CXX";
+
+  # Add preprocessor flags if specified
   push @{$self->{makefile_header}}, "CPPFLAGS := $CPPFLAGS";
+
+  # Add compilers flags if specified
   push @{$self->{makefile_header}}, "CXXFLAGS := $CXXFLAGS";
+
+  # Enable colors by default
+  push @{$self->{makefile_header}}, "export COLORIZED ?= 1";
+
   print("Makefile header generated.\n");
 }
 
@@ -95,6 +110,7 @@ sub create_makefile_targets()
 {
   my $self = shift;
 
+  # Add default target
   push @{$self->{makefile_targets}}, "";
   push @{$self->{makefile_targets}}, "# Default target";
   push @{$self->{makefile_targets}}, "all: tests";
@@ -109,6 +125,7 @@ sub create_makefile_targets()
   push @{$self->{makefile_targets}}, "# Force rebuilding all tests";
   push @{$self->{makefile_targets}}, "force: clean all";
 
+  # Add test targets
   for (my $i = 0; $i < scalar @{$self->{tests}}; $i++)
   {
     my $test = $self->{tests}->[$i];
@@ -123,6 +140,7 @@ sub create_makefile_targets()
     push @{$self->{makefile_targets}}, "$test: \$(BLD)/$test.o";
   }
 
+  # Add additional targets
   push @{$self->{makefile_targets}}, "";
   push @{$self->{makefile_targets}}, "# Phony targets";
   push @{$self->{makefile_targets}}, ".PHONY: all clean distclean help";

--- a/runtest.pl
+++ b/runtest.pl
@@ -1,0 +1,32 @@
+#!/usr/bin/env perl
+
+my $LINEWIDTH = 80;
+my $COLORIZED = 1;
+
+my $testname = shift @ARGV;
+my $logfile = shift @ARGV;
+my @cmds = @ARGV;
+
+open F, '> '.$logfile or die 'open $logfile: $!';
+my $cmd = join(' ', @cmds)." 2>&1 ";
+print F "# Command executed: ";
+print F $cmd;
+print F "\n";
+print F `$cmd`;
+my $returncode = $?;
+close F;
+
+my $status, $statustext;
+
+if ($returncode eq 0)
+{
+  $status = 1;
+  $statustext = 'PASS';
+}
+else
+{
+  $status = 0;
+  $statustext = 'FAIL';
+}
+
+print "$testname".("."x($LINEWIDTH-length($testname)-6)).$statustext."\n";

--- a/runtest.pl
+++ b/runtest.pl
@@ -3,10 +3,12 @@
 my $LINEWIDTH = 80;
 my $COLORIZED = 1;
 
+# Store arguments
 my $testname = shift @ARGV;
 my $logfile = shift @ARGV;
 my @cmds = @ARGV;
 
+# Run test and save results
 open F, '> '.$logfile or die 'open $logfile: $!';
 my $cmd = join(' ', @cmds)." 2>&1 ";
 print F "# Command executed: ";
@@ -16,8 +18,8 @@ print F `$cmd`;
 my $returncode = $?;
 close F;
 
+# Check returncode to set status
 my $status, $statustext;
-
 if ($returncode eq 0)
 {
   $status = 1;
@@ -29,4 +31,19 @@ else
   $statustext = 'FAIL';
 }
 
+# Add coloring if desired
+my $use_colors = $COLORIZED;
+$use_colors = $ENV{COLORIZED} eq 1 if (defined $ENV{COLORIZED});
+if ($use_colors and -t STDIN)
+{
+  if ($status)
+  {
+    $statustext = "\033[32m".$statustext."\033[0m";
+  }
+  else {
+    $statustext = "\033[31m".$statustext."\033[0m";
+  }
+}
+
+# Print status
 print "$testname".("."x($LINEWIDTH-length($testname)-6)).$statustext."\n";


### PR DESCRIPTION
I've used these test suite for testing different compilers we are using on different hardware and this test suite is great.
Nevertheless on almost all the target OS python3 was not available (either not installed at all or still in python 2.x) whereas perl was available, thus I quickly wrote a perl equivalent of both python scripts to use the test suite on these machines.
It can be helpful for others so I submit this PR if it has some interest for someone.
